### PR TITLE
🔧 #50: Switched out faulty renovate config entries

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,11 +34,14 @@
       "schedule": ["every 2 days"]
     }
   ],
-  "enabledManagers": ["cargo"],
-  "cargo": {
-    "enabled": true
-  },
-  "git": {
-    "enabled": true
-  }
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/)Cargo\\.toml$"],
+      "matchStrings": [
+        "(?<depName>[^\\s=]+)\\s*=\\s*\\{[^}]*git\\s*=\\s*\"(?<packageName>https:\\/\\/github\\.\\/[^\"}]+)\"[^}]*rev\\s*=\\s*\"(?<currentValue>[0-9a-f]{7,40})\"[^}]*\\}"
+      ],
+      "datasourceTemplate": "git-refs",
+      "versioningTemplate": "git"
+    }
+  ]
 }


### PR DESCRIPTION
- defined regex matcher for repo-entries in Cargo.toml
- renovate should automatically update the ref-id