### PR TITLE
#58: Improve number of necessary dependenices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,13 @@ readme = "README.md"
 keywords = ["obsbot", "tiny2", "camera", "webcam", "linux"]
 categories = ["hardware-support"]
 
+[features]
+gui = ["iced", "tiny4linux_assets"]
+cli = ["clap", "clap_complete", "dialoguer"]
+
 [dependencies]
-tiny4linux_assets = { git = "https://github.com/OpenFoxes/Tiny4Linux-Icons", rev = "ba11e78" }
-iced = { version = "0.13.0", features = ["image", "tokio"] }
+tiny4linux_assets = { git = "https://github.com/OpenFoxes/Tiny4Linux-Icons", rev = "ba11e78", optional = true }
+iced = { version = "0.13.0", features = ["image", "tokio"], optional = true }
 nix = { version = "0.30.0", features = ["ioctl"] }
 errno = "0.3.14"
 hex = "0.4.3"
@@ -23,17 +27,19 @@ glob = "0.3.3"
 enum_dispatch = "0.3.13"
 thiserror = "2.0.0"
 hexdump = "0.1.2"
-clap = { version = "4.4.18", features = ["derive"] }
-clap_complete = "4.5.59"
-dialoguer = { version = "0.12.0", features = ["fuzzy-select"] }
+clap = { version = "4.4.18", features = ["derive"], optional = true }
+clap_complete = { version = "4.5.59", optional = true }
+dialoguer = { version = "0.12.0", features = ["fuzzy-select"], optional = true }
 
 [build-dependencies]
-tiny4linux_assets = { git = "https://github.com/OpenFoxes/Tiny4Linux-Icons", rev = "ba11e78" }
+tiny4linux_assets = { git = "https://github.com/OpenFoxes/Tiny4Linux-Icons", rev = "ba11e78", optional = true }
 
 [[bin]]
 name = "tiny4linux-gui"
 path = "src/gui/main.rs"
+required-features = ["gui"]
 
 [[bin]]
 name = "tiny4linux-cli"
 path = "src/cli/main.rs"
+required-features = ["cli"]

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,19 @@
-use std::fs;
-use std::path::Path;
-use tiny4linux_assets::absolute_path_for_t4l_asset;
-
 fn main() {
+    let gui_feature_enabled = std::env::var("CARGO_FEATURE_GUI").is_ok();
+
+    if !gui_feature_enabled {
+        return;
+    }
+
+    build_gui_assets();
+}
+
+#[cfg(feature = "gui")]
+fn build_gui_assets() {
+    use std::fs;
+    use std::path::Path;
+    use tiny4linux_assets::absolute_path_for_t4l_asset;
+
     let asset_src = absolute_path_for_t4l_asset("generated/png/title-icon/v2.0-soft-shadow.png");
 
     let out_dir = std::env::var("OUT_DIR").unwrap();
@@ -16,4 +27,9 @@ fn main() {
     fs::copy(&asset_src, &target_dir).unwrap();
 
     println!("cargo:rerun-if-changed={}", asset_src.display());
+}
+
+#[cfg(not(feature = "gui"))]
+fn build_gui_assets() {
+    // Noop
 }

--- a/deployment/cli/aur/PKGBUILD
+++ b/deployment/cli/aur/PKGBUILD
@@ -14,7 +14,7 @@ source=("$url/releases/download/v$pkgver/tiny4linux-$pkgver.tar.gz")
 sha256sums=('2e2fb12ed6080c35dd389a0c0b30906cf9abab0c2fd7035296c7e4fa41728df6')
 
 build() {
-  cargo build --release --locked
+  cargo build --release --features cli --locked
 }
 
 package() {

--- a/deployment/gui/aur/PKGBUILD
+++ b/deployment/gui/aur/PKGBUILD
@@ -14,7 +14,7 @@ source=("$url/releases/download/v$pkgver/tiny4linux-$pkgver.tar.gz")
 sha256sums=('2e2fb12ed6080c35dd389a0c0b30906cf9abab0c2fd7035296c7e4fa41728df6')
 
 build() {
-  cargo build --release --locked
+  cargo build --release --features gui --locked
 }
 
 package() {


### PR DESCRIPTION
This change separates the dependencies, so that the ones, that are only required in the GUI, are only loaded in the GUI-build. Same for the CLI. That improves the number of dependencies drastically, at least for the small CLI-version.